### PR TITLE
Update BrowserRouter to HashRouter

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: "http://localhost:3000/rancid-tomatillos",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -2,94 +2,132 @@ describe("Homepage", () => {
   beforeEach(() => {
     cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies", {
       method: "GET",
-      fixture: "movies.json"
-    }).as('getMovies');
+      fixture: "movies.json",
+    }).as("getMovies");
 
-    cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270", {
-      method: "GET",
-      fixture: "movie-436270.json"
-    }).as('getMovie436270');
+    cy.intercept(
+      "https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270",
+      {
+        method: "GET",
+        fixture: "movie-436270.json",
+      }
+    ).as("getMovie436270");
 
-    cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies/724495", {
-      method: "GET",
-      fixture: "movie-724495.json"
-    }).as('getMovie724495');
+    cy.intercept(
+      "https://rancid-tomatillos.herokuapp.com/api/v2/movies/724495",
+      {
+        method: "GET",
+        fixture: "movie-724495.json",
+      }
+    ).as("getMovie724495");
 
-    cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies/634649", {
-      method: "GET",
-      fixture: "movie-634649.json"
-    }).as('getMovie634649');
+    cy.intercept(
+      "https://rancid-tomatillos.herokuapp.com/api/v2/movies/634649",
+      {
+        method: "GET",
+        fixture: "movie-634649.json",
+      }
+    ).as("getMovie634649");
 
-    cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies/414906", {
-      method: "GET",
-      fixture: "movie-414906.json"
-    }).as('getMovie414906');
+    cy.intercept(
+      "https://rancid-tomatillos.herokuapp.com/api/v2/movies/414906",
+      {
+        method: "GET",
+        fixture: "movie-414906.json",
+      }
+    ).as("getMovie414906");
 
-    cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies/438148", {
-      method: "GET",
-      fixture: "movie-438148.json"
-    }).as('getMovie438148');
+    cy.intercept(
+      "https://rancid-tomatillos.herokuapp.com/api/v2/movies/438148",
+      {
+        method: "GET",
+        fixture: "movie-438148.json",
+      }
+    ).as("getMovie438148");
 
-    cy.visit('http://localhost:3000/');
+    cy.visit("/");
   });
 
   it("Should display the header with the search bar", () => {
     cy.get("header").should("be.visible");
-    cy.get("input[type='text']").should("have.attr", "placeholder", "Search movies");
+    cy.get("input[type='text']").should(
+      "have.attr",
+      "placeholder",
+      "Search movies"
+    );
   });
 
   it("Should display the hero section with featured movies", () => {
-    cy.wait('@getMovies');
-    cy.wait('@getMovie436270');
-    cy.wait('@getMovie724495');
-    cy.wait('@getMovie634649');
-    cy.wait('@getMovie414906');
-    cy.wait('@getMovie438148');
+    cy.wait("@getMovies");
+    cy.wait("@getMovie436270");
+    cy.wait("@getMovie724495");
+    cy.wait("@getMovie634649");
+    cy.wait("@getMovie414906");
+    cy.wait("@getMovie438148");
 
-    cy.get(".hero").should('exist');
-    cy.get(".hero-content").should('be.visible');
+    cy.get(".hero").should("exist");
+    cy.get(".hero-content").should("be.visible");
 
-    cy.get(".hero").first().within(() => {
-      cy.get(".hero-title").contains('Black Adam');
-      cy.get(".hero-rating").contains('4.0');
-      cy.get(".hero-details").contains('2022');
-      cy.get(".hero-details").contains('125 min');
-      cy.get(".hero-details").contains('Action');
-      cy.get(".hero-overview").contains('Nearly 5,000 years after he was bestowed with the almighty powers of the Egyptian gods—and imprisoned just as quickly—Black Adam is freed from his earthly tomb, ready to unleash his unique form of justice on the modern world.');
-    });
+    cy.get(".hero")
+      .first()
+      .within(() => {
+        cy.get(".hero-title").contains("Black Adam");
+        cy.get(".hero-rating").contains("4.0");
+        cy.get(".hero-details").contains("2022");
+        cy.get(".hero-details").contains("125 min");
+        cy.get(".hero-details").contains("Action");
+        cy.get(".hero-overview").contains(
+          "Nearly 5,000 years after he was bestowed with the almighty powers of the Egyptian gods—and imprisoned just as quickly—Black Adam is freed from his earthly tomb, ready to unleash his unique form of justice on the modern world."
+        );
+      });
   });
 
   it("Should display a grid of movies in the movies container", () => {
-    cy.wait('@getMovies');
-    cy.get('.movies-container').should('exist');
-    cy.get('.movies-container .movie').should('have.length', 5);
+    cy.wait("@getMovies");
+    cy.get(".movies-container").should("exist");
+    cy.get(".movies-container .movie").should("have.length", 5);
 
-    cy.get('.movies-container .movie').first().within(() => {
-      cy.get('.movie--title').contains('Black Adam');
-      cy.get('.movie--poster img').should('have.attr', 'src').should('include', 'pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg');
-    });
+    cy.get(".movies-container .movie")
+      .first()
+      .within(() => {
+        cy.get(".movie--title").contains("Black Adam");
+        cy.get(".movie--poster img")
+          .should("have.attr", "src")
+          .should("include", "pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg");
+      });
 
-    cy.get('.movies-container .movie').last().within(() => {
-      cy.get('.movie--title').contains('Minions: The Rise of Gru');
-      cy.get('.movie--poster img').should('have.attr', 'src').should('include', 'rwgmDkIEv8VjAsWx25ottJrFvpO.jpg');
-    });
+    cy.get(".movies-container .movie")
+      .last()
+      .within(() => {
+        cy.get(".movie--title").contains("Minions: The Rise of Gru");
+        cy.get(".movie--poster img")
+          .should("have.attr", "src")
+          .should("include", "rwgmDkIEv8VjAsWx25ottJrFvpO.jpg");
+      });
   });
 
   it("Should navigate to the appropriate movie page when a movie poster is clicked", () => {
-    cy.wait('@getMovie436270');
+    cy.wait("@getMovie436270");
 
     // ensure the first movie poster is visible and enabled before clicking. $el is a varaible indicating that this is a wrapped element
-    cy.get('.movies-container .movie').first().should('be.visible').then(($el) => {
-      cy.wrap($el).click();
-    });
-    cy.url().should('include', '/436270');
-    cy.wait('@getMovie436270');
+    cy.get(".movies-container .movie")
+      .first()
+      .should("be.visible")
+      .then(($el) => {
+        cy.wrap($el).click();
+      });
+    cy.url().should("include", "/436270");
+    cy.wait("@getMovie436270");
 
-    cy.get('[data-test-id="movie-title"]').should('be.visible').contains("Black Adam");
+    cy.get('[data-test-id="movie-title"]')
+      .should("be.visible")
+      .contains("Black Adam");
     cy.wait(500);
 
-    cy.get('[data-test-id="return-home-button"]').should('be.visible').click({ force: true });
+    cy.get('[data-test-id="return-home-button"]')
+      .should("be.visible")
+      .click({ force: true });
 
-    cy.url().should('eq', 'http://localhost:3000/');
+    cy.url().should("eq", "http://localhost:3000/rancid-tomatillos/#/");
   });
 });

--- a/cypress/e2e/movie_detail.cy.js
+++ b/cypress/e2e/movie_detail.cy.js
@@ -54,7 +54,7 @@ describe("template spec", () => {
     );
 
     // navigate to the first mock movie
-    cy.visit("/694919");
+    cy.visit("/#/694919");
 
     // should have a header and no footer
     cy.get("header");
@@ -133,7 +133,7 @@ describe("template spec", () => {
     );
 
     // navigate to the last mock movie
-    cy.visit("/585244");
+    cy.visit("/#/585244");
 
     // should have a header and no footer
     cy.get("header");

--- a/cypress/e2e/movie_missing.cy.js
+++ b/cypress/e2e/movie_missing.cy.js
@@ -2,7 +2,7 @@ describe("template spec", () => {
   it("Going to an invalid URL will take you to the missing page", () => {
     const baseUrl = Cypress.config("baseUrl");
     // needs a movie page that we know is not correct
-    cy.visit("/1337");
+    cy.visit("/#/1337");
     cy.getTestId("movie-missing")
       .should("include.text", "Whoops!")
       .and(
@@ -15,7 +15,7 @@ describe("template spec", () => {
     cy.url().should("include", `${baseUrl}/`);
 
     // do it again on another wrong URL correct
-    cy.visit("/420");
+    cy.visit("/#/420");
     cy.getTestId("movie-missing")
       .should("include.text", "Whoops!")
       .and(
@@ -25,6 +25,6 @@ describe("template spec", () => {
 
     // Should return to main page after 5 seconds
     cy.wait(6000);
-    cy.url().should("include", `${baseUrl}/`);
+    cy.url().should("include", `${baseUrl}/#/`);
   });
 });

--- a/cypress/e2e/searchbar.cy.js
+++ b/cypress/e2e/searchbar.cy.js
@@ -17,7 +17,7 @@ describe("template spec", () => {
       .type("afTer We Collided")
       .should("have.value", "afTer We Collided");
     cy.getTestId("search-result").should("have.length", 1).click();
-    cy.url().should("include", `${baseURL}/613504`);
+    cy.url().should("include", `${baseURL}/#/613504`);
 
     // will clear on click off
     cy.get("body").click(0, 0);
@@ -35,7 +35,7 @@ describe("template spec", () => {
       .and("contain", "2020");
 
     cy.getTestId("search-result").first().click();
-    cy.url().should("include", `${baseURL}/627290`);
+    cy.url().should("include", `${baseURL}/#/627290`);
     cy.visit("/");
 
     cy.getTestId("search-bar-input").type("m");
@@ -45,7 +45,7 @@ describe("template spec", () => {
       .and("contain", "5.0/10.0")
       .and("contain", "2020");
     cy.getTestId("search-result").last().click();
-    cy.url().should("include", `${baseURL}/659991`);
+    cy.url().should("include", `${baseURL}/#/659991`);
     cy.visit("/");
 
     // can look up something that doesn't exist
@@ -68,25 +68,25 @@ describe("template spec", () => {
     cy.get("body").type("{downArrow}{enter}");
     cy.getTestId("search-results").should("not.exist");
     cy.getTestId("search-bar-input").should("have.value", "");
-    cy.url().should("include", `${baseURL}/500840`);
+    cy.url().should("include", `${baseURL}/#/500840`);
 
     cy.visit("/");
 
     cy.getTestId("search-bar-input").type("k");
     cy.get("body").type("{downArrow}{downArrow}{enter}");
-    cy.url().should("include", `${baseURL}/579583`);
+    cy.url().should("include", `${baseURL}/#/579583`);
 
     cy.visit("/");
 
     cy.getTestId("search-bar-input").type("k");
     cy.get("body").type("{upArrow}{enter}");
-    cy.url().should("include", `${baseURL}/579583`);
+    cy.url().should("include", `${baseURL}/#/579583`);
 
     cy.visit("/");
 
     cy.getTestId("search-bar-input").type("k");
     cy.get("body").type("{upArrow}{upArrow}{enter}");
-    cy.url().should("include", `${baseURL}/500840`);
+    cy.url().should("include", `${baseURL}/#/500840`);
 
     cy.visit("/");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "cypress": "^13.9.0"
+        "cypress": "^13.9.0",
+        "gh-pages": "^6.1.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5340,6 +5341,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -7935,6 +7945,12 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.759.tgz",
       "integrity": "sha512-qZJc+zsuI+/5UjOSFnpkJBwwLMH1AZgyKqJ7LUNnRsB7v/cDjMu9DvXgp9kH6PTTZxjnPXGp2Uhurw+2Ll4Hjg=="
     },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true
+    },
     "node_modules/emittery": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
@@ -9308,6 +9324,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/filesize": {
       "version": "8.0.7",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
@@ -9821,6 +9863,79 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.1.1.tgz",
+      "integrity": "sha512-upnohfjBwN5hBP9w2dPE7HO5JJTHzSGMV1JrLrHvNuqmjoYHg6TBrCcnEoorjG/e0ejbuvnwyKMdTyM40PEByw==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^11.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^6.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gh-pages/node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gh-pages/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/gh-pages/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/gh-pages/node_modules/globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
@@ -14627,6 +14742,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -17956,6 +18092,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -18495,6 +18643,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/tryer": {
@@ -23716,6 +23876,12 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true
+    },
     "array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -25604,6 +25770,12 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.759.tgz",
       "integrity": "sha512-qZJc+zsuI+/5UjOSFnpkJBwwLMH1AZgyKqJ7LUNnRsB7v/cDjMu9DvXgp9kH6PTTZxjnPXGp2Uhurw+2Ll4Hjg=="
     },
+    "email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true
+    },
     "emittery": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
@@ -26624,6 +26796,23 @@
         }
       }
     },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      }
+    },
     "filesize": {
       "version": "8.0.7",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
@@ -26973,6 +27162,62 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "gh-pages": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.1.1.tgz",
+      "integrity": "sha512-upnohfjBwN5hBP9w2dPE7HO5JJTHzSGMV1JrLrHvNuqmjoYHg6TBrCcnEoorjG/e0ejbuvnwyKMdTyM40PEByw==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.4",
+        "commander": "^11.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^6.1.0"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+          "dev": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "commander": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "glob": {
@@ -30412,6 +30657,21 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
     "pirates": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -32654,6 +32914,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
     "style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -33048,6 +33317,15 @@
       "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "tryer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "rancid-tomatillos",
   "version": "0.1.0",
+  "homepage": "https://KojinKuro.github.io/rancid-tomatillos",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
@@ -20,6 +21,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "e2e": "cypress open"
@@ -43,6 +46,7 @@
     ]
   },
   "devDependencies": {
-    "cypress": "^13.9.0"
+    "cypress": "^13.9.0",
+    "gh-pages": "^6.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,18 +2,18 @@ import "boxicons";
 import "normalize.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <BrowserRouter>
+  <HashRouter>
     <React.StrictMode>
       <App />
     </React.StrictMode>
-  </BrowserRouter>
+  </HashRouter>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
# Description

Use `<HashRouter />` instead of `<BrowserRouter />`

## Context

Hash router works better with GitHub Pages, so we are using that now, so the Github Pages live deployment will work. All tests have been updated to make sure that this works.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] e2e testing w/ Cypress. Run `npm run e2e` and check the Cypress tests. Everything should still pass.
- [ ] Manual testing. Clicked around the site in the development build and the production build and everything still works.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
